### PR TITLE
A skel of embedding grammars for tests in musl env

### DIFF
--- a/.github/workflows/fast_checks.yml
+++ b/.github/workflows/fast_checks.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cargo fmt
-        run: cargo fmt -- --check
+        run: ./script/fetch-fixtures && cargo fmt -- --check
 
   check_c_warnings:
     name: Check C warnings

--- a/.github/workflows/fast_checks.yml
+++ b/.github/workflows/fast_checks.yml
@@ -9,23 +9,21 @@ on:
 
 jobs:
   check_rust_formatting:
-    name: Check Rust formating
+    name: Check Rust formatting
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
 
-    - name: Checkout source code
-      uses: actions/checkout@v3
-
-    - name: Run cargo fmt
-      run: cargo fmt -- --check
+      - name: Run cargo fmt
+        run: cargo fmt -- --check
 
   check_c_warnings:
     name: Check C warnings
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
 
-    - name: Checkout source code
-      uses: actions/checkout@v3
-
-    - name: Make C library to check that it's able to compile without warnings
-      run: make -j CFLAGS="-Werror"
+      - name: Make C library to check that it's able to compile without warnings
+        run: make -j CFLAGS="-Werror"

--- a/.github/workflows/full_rust_checks.yml
+++ b/.github/workflows/full_rust_checks.yml
@@ -12,21 +12,20 @@ jobs:
     name: Run checks
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
 
-    - name: Checkout source code
-      uses: actions/checkout@v3
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
 
-    - name: Install rust toolchain
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
-        components: clippy, rustfmt
+      - name: Run cargo fmt
+        run: ./script/fetch-fixtures && cargo fmt -- --check
 
-    - name: Run cargo fmt
-      run: cargo fmt -- --check
+      # - name: Run clippy
+      #   run: cargo clippy --all-targets
 
-    # - name: Run clippy
-    #   run: cargo clippy --all-targets
-
-    - name: Run cargo check
-      run: cargo check --workspace --examples --tests --benches --bins
+      - name: Run cargo check
+        run: cargo check --workspace --examples --tests --benches --bins

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,10 +829,56 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad726ec26496bf4c083fff0f43d4eb3a2ad1bba305323af5ff91383c0b6ecac0"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter"
 version = "0.20.10"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.20.3"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -866,12 +912,27 @@ dependencies = [
  "tempfile",
  "tiny_http",
  "toml",
- "tree-sitter",
+ "tree-sitter 0.20.10",
+ "tree-sitter-bash",
+ "tree-sitter-c",
  "tree-sitter-config",
+ "tree-sitter-cpp",
+ "tree-sitter-embedded-template",
+ "tree-sitter-go",
  "tree-sitter-highlight",
+ "tree-sitter-html",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-jsdoc",
+ "tree-sitter-json",
  "tree-sitter-loader",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
  "tree-sitter-tags",
  "tree-sitter-tests-proc-macro",
+ "tree-sitter-typescript",
  "unindent",
  "walkdir",
  "webbrowser",
@@ -889,13 +950,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-cpp"
+version = "0.20.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-embedded-template"
+version = "0.20.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.19.1"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tree-sitter-highlight"
 version = "0.20.2"
 dependencies = [
  "lazy_static",
  "regex",
  "thiserror",
- "tree-sitter",
+ "tree-sitter 0.20.10",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.19.5",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.20.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.16.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.17.1",
+]
+
+[[package]]
+name = "tree-sitter-jsdoc"
+version = "0.0.1"
+dependencies = [
+ "cc",
+ "tree-sitter 0.17.1",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.20.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -910,9 +1035,41 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tree-sitter",
+ "tree-sitter 0.20.10",
  "tree-sitter-highlight",
  "tree-sitter-tags",
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.19.1"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.20.2"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.20.0"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.3"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -922,7 +1079,7 @@ dependencies = [
  "memchr",
  "regex",
  "thiserror",
- "tree-sitter",
+ "tree-sitter 0.20.10",
 ]
 
 [[package]]
@@ -933,6 +1090,14 @@ dependencies = [
  "quote",
  "rand",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.20.2"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "86b8f9420f797f2d9e935edf629310eb938a0d839f984e25327f3c7eed22300c"
 dependencies = [
  "memchr",
 ]
@@ -38,22 +38,22 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bumpalo"
@@ -69,9 +69,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cesu8"
@@ -99,7 +102,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -139,7 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
 dependencies = [
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -207,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"
@@ -219,9 +222,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -240,12 +243,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "form_urlencoded"
@@ -287,12 +287,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "home"
@@ -343,26 +337,6 @@ name = "indoc"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "itoa"
@@ -425,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
@@ -462,7 +436,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -528,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -577,7 +551,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -586,7 +560,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -602,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -614,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -637,13 +611,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -672,29 +645,29 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.173"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91f70896d6720bc714a4a57d22fc91f1db634680e65c8efe13323f1fa38d53f"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.173"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6250dde8342e0232232be9ca3db7aa40aceb5a3e5dd9bddbc00d99a007cde49"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -742,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,11 +726,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
@@ -776,22 +748,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -860,7 +832,6 @@ name = "tree-sitter"
 version = "0.20.10"
 dependencies = [
  "cc",
- "lazy_static",
  "regex",
 ]
 
@@ -1057,7 +1028,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -1079,7 +1050,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1293,9 +1264,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "4344c9f03e6918ce61d94ea6b0500964bb42ee9ca9b2c9c8931990e20b481144"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,9 @@ rust-version = "1.65"
 [profile.release]
 strip = true      # Automatically strip symbols from the binary.
 lto = true        # Link-time optimization.
-opt-level = "s"   # Optimize for speed.
+opt-level = 3     # Optimization level 3.
 codegen-units = 1 # Maximum size reduction optimizations.
+
+[profile.size]
+inherits = "release"
+opt-level = "s"      # Optimize for size.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -85,18 +85,18 @@ unindent = "0.2.2"
 indoc = "2.0.3"
 
 [target.'cfg(target_env = "musl")'.dev-dependencies]
-tree-sitter-bash = { path = "../test/fixtures/grammars/bash/" }
-tree-sitter-c = { path = "../test/fixtures/grammars/c/" }
-tree-sitter-cpp = { path = "../test/fixtures/grammars/cpp/" }
-tree-sitter-embedded-template = { path = "../test/fixtures/grammars/embedded-template/" }
-tree-sitter-go = { path = "../test/fixtures/grammars/go/" }
-tree-sitter-html = { path = "../test/fixtures/grammars/html/" }
-tree-sitter-java = { path = "../test/fixtures/grammars/java/" }
-tree-sitter-javascript = { path = "../test/fixtures/grammars/javascript/" }
-tree-sitter-jsdoc = { path = "../test/fixtures/grammars/jsdoc/" }
-tree-sitter-json = { path = "../test/fixtures/grammars/json/" }
-tree-sitter-php = { path = "../test/fixtures/grammars/php/" }
-tree-sitter-python = { path = "../test/fixtures/grammars/python/" }
-tree-sitter-ruby = { path = "../test/fixtures/grammars/ruby/" }
-tree-sitter-rust = { path = "../test/fixtures/grammars/rust/" }
-tree-sitter-typescript = { path = "../test/fixtures/grammars/typescript/" }
+tree-sitter-bash = { path = "../test/fixtures/grammars/bash/", version = "0.19.0" }
+tree-sitter-c = { path = "../test/fixtures/grammars/c/", version = "0.20.6" }
+tree-sitter-cpp = { path = "../test/fixtures/grammars/cpp/", version = "0.20.3" }
+tree-sitter-embedded-template = { path = "../test/fixtures/grammars/embedded-template/", version = "0.20.0" }
+tree-sitter-go = { path = "../test/fixtures/grammars/go/", version = "0.20.0" }
+tree-sitter-html = { path = "../test/fixtures/grammars/html/", version = "0.20.0" }
+tree-sitter-java = { path = "../test/fixtures/grammars/java/", version = "0.20.0" }
+tree-sitter-javascript = { path = "../test/fixtures/grammars/javascript/", version = "0.20.0" }
+tree-sitter-jsdoc = { path = "../test/fixtures/grammars/jsdoc/", version = "0.20.0" }
+tree-sitter-json = { path = "../test/fixtures/grammars/json/", version = "0.20.0" }
+tree-sitter-php = { path = "../test/fixtures/grammars/php/", version = "0.20.0" }
+tree-sitter-python = { path = "../test/fixtures/grammars/python/", version = "0.20.0" }
+tree-sitter-ruby = { path = "../test/fixtures/grammars/ruby/", version = "0.20.0" }
+tree-sitter-rust = { path = "../test/fixtures/grammars/rust/", version = "0.20.0" }
+tree-sitter-typescript = { path = "../test/fixtures/grammars/typescript/", version = "0.20.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,9 @@ features = ["preserve_order"]
 version = "0.4.19"
 features = ["std"]
 
+[build-dependencies]
+toml = "0.7.6"
+
 [dev-dependencies]
 tree_sitter_proc_macro = { path = "src/tests/proc_macro", package = "tree-sitter-tests-proc-macro" }
 
@@ -81,5 +84,19 @@ ctor = "0.2.4"
 unindent = "0.2.2"
 indoc = "2.0.3"
 
-[build-dependencies]
-toml = "0.7.6"
+[target.'cfg(target_env = "musl")'.dev-dependencies]
+tree-sitter-bash = { path = "../test/fixtures/grammars/bash/" }
+tree-sitter-c = { path = "../test/fixtures/grammars/c/" }
+tree-sitter-cpp = { path = "../test/fixtures/grammars/cpp/" }
+tree-sitter-embedded-template = { path = "../test/fixtures/grammars/embedded-template/" }
+tree-sitter-go = { path = "../test/fixtures/grammars/go/" }
+tree-sitter-html = { path = "../test/fixtures/grammars/html/" }
+tree-sitter-java = { path = "../test/fixtures/grammars/java/" }
+tree-sitter-javascript = { path = "../test/fixtures/grammars/javascript/" }
+tree-sitter-jsdoc = { path = "../test/fixtures/grammars/jsdoc/" }
+tree-sitter-json = { path = "../test/fixtures/grammars/json/" }
+tree-sitter-php = { path = "../test/fixtures/grammars/php/" }
+tree-sitter-python = { path = "../test/fixtures/grammars/python/" }
+tree-sitter-ruby = { path = "../test/fixtures/grammars/ruby/" }
+tree-sitter-rust = { path = "../test/fixtures/grammars/rust/" }
+tree-sitter-typescript = { path = "../test/fixtures/grammars/typescript/" }

--- a/cli/src/generate/build_tables/token_conflicts.rs
+++ b/cli/src/generate/build_tables/token_conflicts.rs
@@ -390,12 +390,12 @@ mod tests {
                 Variable {
                     name: "token_0".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::pattern("[a-f]1|0x\\d"),
+                    rule: Rule::pattern("[a-f]1|0x\\d", ""),
                 },
                 Variable {
                     name: "token_1".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::pattern("d*ef"),
+                    rule: Rule::pattern("d*ef", ""),
                 },
             ],
         })
@@ -426,7 +426,7 @@ mod tests {
                 Variable {
                     name: "identifier".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::pattern("\\w+"),
+                    rule: Rule::pattern("\\w+", ""),
                 },
                 Variable {
                     name: "instanceof".to_string(),
@@ -471,7 +471,7 @@ mod tests {
     #[test]
     fn test_token_conflicts_with_separators() {
         let grammar = expand_tokens(ExtractedLexicalGrammar {
-            separators: vec![Rule::pattern("\\s")],
+            separators: vec![Rule::pattern("\\s", "")],
             variables: vec![
                 Variable {
                     name: "x".to_string(),
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn test_token_conflicts_with_open_ended_tokens() {
         let grammar = expand_tokens(ExtractedLexicalGrammar {
-            separators: vec![Rule::pattern("\\s")],
+            separators: vec![Rule::pattern("\\s", "")],
             variables: vec![
                 Variable {
                     name: "x".to_string(),
@@ -508,7 +508,7 @@ mod tests {
                 Variable {
                     name: "anything".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::prec(Precedence::Integer(-1), Rule::pattern(".*")),
+                    rule: Rule::prec(Precedence::Integer(-1), Rule::pattern(".*", "")),
                 },
             ],
         })

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -181,10 +181,13 @@ function normalize(value) {
         value
       };
     case RegExp:
-      return {
+      return value.flags ? {
         type: 'PATTERN',
         value: value.source,
         flags: value.flags
+      } : {
+        type: 'PATTERN',
+        value: value.source
       };
     case ReferenceError:
       throw value

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -183,7 +183,8 @@ function normalize(value) {
     case RegExp:
       return {
         type: 'PATTERN',
-        value: value.source
+        value: value.source,
+        flags: value.flags
       };
     case ReferenceError:
       throw value

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -1172,12 +1172,12 @@ mod tests {
                 Variable {
                     name: "identifier".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::pattern("\\w+"),
+                    rule: Rule::pattern("\\w+", ""),
                 },
                 Variable {
                     name: "foo_identifier".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::pattern("[\\w-]+"),
+                    rule: Rule::pattern("[\\w-]+", ""),
                 },
             ],
             ..Default::default()
@@ -1275,8 +1275,8 @@ mod tests {
                 name: "script".to_string(),
                 kind: VariableType::Named,
                 rule: Rule::seq(vec![
-                    Rule::field("a".to_string(), Rule::pattern("hi")),
-                    Rule::field("b".to_string(), Rule::pattern("bye")),
+                    Rule::field("a".to_string(), Rule::pattern("hi", "")),
+                    Rule::field("b".to_string(), Rule::pattern("bye", "")),
                 ]),
             }],
             ..Default::default()

--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -19,6 +19,7 @@ enum RuleJSON {
     },
     PATTERN {
         value: String,
+        flags: Option<String>,
     },
     SYMBOL {
         name: String,
@@ -143,7 +144,21 @@ fn parse_rule(json: RuleJSON) -> Rule {
         } => Rule::alias(parse_rule(*content), value, named),
         RuleJSON::BLANK => Rule::Blank,
         RuleJSON::STRING { value } => Rule::String(value),
-        RuleJSON::PATTERN { value } => Rule::Pattern(value),
+        RuleJSON::PATTERN { value, flags } => Rule::Pattern(
+            value,
+            flags.map_or(String::new(), |f| {
+                f.chars()
+                    .filter(|c| {
+                        if *c != 'i' {
+                            eprintln!("Warning: unsupported flag {}", c);
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .collect()
+            }),
+        ),
         RuleJSON::SYMBOL { name } => Rule::NamedSymbol(name),
         RuleJSON::CHOICE { members } => Rule::choice(members.into_iter().map(parse_rule).collect()),
         RuleJSON::FIELD { content, name } => Rule::field(name, parse_rule(*content)),

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -139,10 +139,10 @@ pub(crate) fn expand_tokens(mut grammar: ExtractedLexicalGrammar) -> Result<Lexi
 impl NfaBuilder {
     fn expand_rule(&mut self, rule: &Rule, mut next_state_id: u32) -> Result<bool> {
         match rule {
-            Rule::Pattern(s) => {
+            Rule::Pattern(s, f) => {
                 let s = preprocess_regex(s);
                 let ast = parse::Parser::new().parse(&s)?;
-                self.expand_regex(&ast, next_state_id)
+                self.expand_regex(&ast, next_state_id, f.contains('i'))
             }
             Rule::String(s) => {
                 for c in s.chars().rev() {
@@ -210,12 +210,42 @@ impl NfaBuilder {
         }
     }
 
-    fn expand_regex(&mut self, ast: &Ast, mut next_state_id: u32) -> Result<bool> {
+    fn expand_regex(
+        &mut self,
+        ast: &Ast,
+        mut next_state_id: u32,
+        case_insensitive: bool,
+    ) -> Result<bool> {
+        fn inverse_char(c: char) -> char {
+            match c {
+                'a'..='z' => (c as u8 - b'a' + b'A') as char,
+                'A'..='Z' => (c as u8 - b'A' + b'a') as char,
+                c => c,
+            }
+        }
+
+        fn with_inverse_char(mut chars: CharacterSet) -> CharacterSet {
+            for char in chars.clone().chars() {
+                let inverted = inverse_char(char);
+                if char != inverted {
+                    chars = chars.add_char(inverted);
+                }
+            }
+            chars
+        }
+
         match ast {
             Ast::Empty(_) => Ok(false),
             Ast::Flags(_) => Err(anyhow!("Regex error: Flags are not supported")),
             Ast::Literal(literal) => {
-                self.push_advance(CharacterSet::from_char(literal.c), next_state_id);
+                let mut char_set = CharacterSet::from_char(literal.c);
+                if case_insensitive {
+                    let inverted = inverse_char(literal.c);
+                    if literal.c != inverted {
+                        char_set = char_set.add_char(inverted);
+                    }
+                }
+                self.push_advance(char_set, next_state_id);
                 Ok(true)
             }
             Ast::Dot(_) => {
@@ -229,6 +259,9 @@ impl NfaBuilder {
                     if class.negated {
                         chars = chars.negate();
                     }
+                    if case_insensitive {
+                        chars = with_inverse_char(chars);
+                    }
                     self.push_advance(chars, next_state_id);
                     Ok(true)
                 }
@@ -236,6 +269,9 @@ impl NfaBuilder {
                     let mut chars = self.expand_perl_character_class(&class.kind);
                     if class.negated {
                         chars = chars.negate();
+                    }
+                    if case_insensitive {
+                        chars = with_inverse_char(chars);
                     }
                     self.push_advance(chars, next_state_id);
                     Ok(true)
@@ -245,48 +281,56 @@ impl NfaBuilder {
                     if class.negated {
                         chars = chars.negate();
                     }
+                    if case_insensitive {
+                        chars = with_inverse_char(chars);
+                    }
                     self.push_advance(chars, next_state_id);
                     Ok(true)
                 }
             },
             Ast::Repetition(repetition) => match repetition.op.kind {
                 RepetitionKind::ZeroOrOne => {
-                    self.expand_zero_or_one(&repetition.ast, next_state_id)
+                    self.expand_zero_or_one(&repetition.ast, next_state_id, case_insensitive)
                 }
                 RepetitionKind::OneOrMore => {
-                    self.expand_one_or_more(&repetition.ast, next_state_id)
+                    self.expand_one_or_more(&repetition.ast, next_state_id, case_insensitive)
                 }
                 RepetitionKind::ZeroOrMore => {
-                    self.expand_zero_or_more(&repetition.ast, next_state_id)
+                    self.expand_zero_or_more(&repetition.ast, next_state_id, case_insensitive)
                 }
                 RepetitionKind::Range(RepetitionRange::Exactly(count)) => {
-                    self.expand_count(&repetition.ast, count, next_state_id)
+                    self.expand_count(&repetition.ast, count, next_state_id, case_insensitive)
                 }
                 RepetitionKind::Range(RepetitionRange::AtLeast(min)) => {
-                    if self.expand_zero_or_more(&repetition.ast, next_state_id)? {
-                        self.expand_count(&repetition.ast, min, next_state_id)
+                    if self.expand_zero_or_more(&repetition.ast, next_state_id, case_insensitive)? {
+                        self.expand_count(&repetition.ast, min, next_state_id, case_insensitive)
                     } else {
                         Ok(false)
                     }
                 }
                 RepetitionKind::Range(RepetitionRange::Bounded(min, max)) => {
-                    let mut result = self.expand_count(&repetition.ast, min, next_state_id)?;
+                    let mut result =
+                        self.expand_count(&repetition.ast, min, next_state_id, case_insensitive)?;
                     for _ in min..max {
                         if result {
                             next_state_id = self.nfa.last_state_id();
                         }
-                        if self.expand_zero_or_one(&repetition.ast, next_state_id)? {
+                        if self.expand_zero_or_one(
+                            &repetition.ast,
+                            next_state_id,
+                            case_insensitive,
+                        )? {
                             result = true;
                         }
                     }
                     Ok(result)
                 }
             },
-            Ast::Group(group) => self.expand_regex(&group.ast, next_state_id),
+            Ast::Group(group) => self.expand_regex(&group.ast, next_state_id, case_insensitive),
             Ast::Alternation(alternation) => {
                 let mut alternative_state_ids = Vec::new();
                 for ast in alternation.asts.iter() {
-                    if self.expand_regex(&ast, next_state_id)? {
+                    if self.expand_regex(&ast, next_state_id, case_insensitive)? {
                         alternative_state_ids.push(self.nfa.last_state_id());
                     } else {
                         alternative_state_ids.push(next_state_id);
@@ -304,7 +348,7 @@ impl NfaBuilder {
             Ast::Concat(concat) => {
                 let mut result = false;
                 for ast in concat.asts.iter().rev() {
-                    if self.expand_regex(&ast, next_state_id)? {
+                    if self.expand_regex(&ast, next_state_id, case_insensitive)? {
                         result = true;
                         next_state_id = self.nfa.last_state_id();
                     }
@@ -335,13 +379,18 @@ impl NfaBuilder {
         }
     }
 
-    fn expand_one_or_more(&mut self, ast: &Ast, next_state_id: u32) -> Result<bool> {
+    fn expand_one_or_more(
+        &mut self,
+        ast: &Ast,
+        next_state_id: u32,
+        case_insensitive: bool,
+    ) -> Result<bool> {
         self.nfa.states.push(NfaState::Accept {
             variable_index: 0,
             precedence: 0,
         }); // Placeholder for split
         let split_state_id = self.nfa.last_state_id();
-        if self.expand_regex(&ast, split_state_id)? {
+        if self.expand_regex(&ast, split_state_id, case_insensitive)? {
             self.nfa.states[split_state_id as usize] =
                 NfaState::Split(self.nfa.last_state_id(), next_state_id);
             Ok(true)
@@ -351,8 +400,13 @@ impl NfaBuilder {
         }
     }
 
-    fn expand_zero_or_one(&mut self, ast: &Ast, next_state_id: u32) -> Result<bool> {
-        if self.expand_regex(ast, next_state_id)? {
+    fn expand_zero_or_one(
+        &mut self,
+        ast: &Ast,
+        next_state_id: u32,
+        case_insensitive: bool,
+    ) -> Result<bool> {
+        if self.expand_regex(ast, next_state_id, case_insensitive)? {
             self.push_split(next_state_id);
             Ok(true)
         } else {
@@ -360,8 +414,13 @@ impl NfaBuilder {
         }
     }
 
-    fn expand_zero_or_more(&mut self, ast: &Ast, next_state_id: u32) -> Result<bool> {
-        if self.expand_one_or_more(&ast, next_state_id)? {
+    fn expand_zero_or_more(
+        &mut self,
+        ast: &Ast,
+        next_state_id: u32,
+        case_insensitive: bool,
+    ) -> Result<bool> {
+        if self.expand_one_or_more(&ast, next_state_id, case_insensitive)? {
             self.push_split(next_state_id);
             Ok(true)
         } else {
@@ -369,10 +428,16 @@ impl NfaBuilder {
         }
     }
 
-    fn expand_count(&mut self, ast: &Ast, count: u32, mut next_state_id: u32) -> Result<bool> {
+    fn expand_count(
+        &mut self,
+        ast: &Ast,
+        count: u32,
+        mut next_state_id: u32,
+        case_insensitive: bool,
+    ) -> Result<bool> {
         let mut result = false;
         for _ in 0..count {
-            if self.expand_regex(ast, next_state_id)? {
+            if self.expand_regex(ast, next_state_id, case_insensitive)? {
                 result = true;
                 next_state_id = self.nfa.last_state_id();
             }
@@ -565,7 +630,7 @@ mod tests {
         let table = [
             // regex with sequences and alternatives
             Row {
-                rules: vec![Rule::pattern("(a|b|c)d(e|f|g)h?")],
+                rules: vec![Rule::pattern("(a|b|c)d(e|f|g)h?", "")],
                 separators: vec![],
                 examples: vec![
                     ("ade1", Some((0, "ade"))),
@@ -576,13 +641,13 @@ mod tests {
             },
             // regex with repeats
             Row {
-                rules: vec![Rule::pattern("a*")],
+                rules: vec![Rule::pattern("a*", "")],
                 separators: vec![],
                 examples: vec![("aaa1", Some((0, "aaa"))), ("b", Some((0, "")))],
             },
             // regex with repeats in sequences
             Row {
-                rules: vec![Rule::pattern("a((bc)+|(de)*)f")],
+                rules: vec![Rule::pattern("a((bc)+|(de)*)f", "")],
                 separators: vec![],
                 examples: vec![
                     ("af1", Some((0, "af"))),
@@ -593,13 +658,13 @@ mod tests {
             },
             // regex with character ranges
             Row {
-                rules: vec![Rule::pattern("[a-fA-F0-9]+")],
+                rules: vec![Rule::pattern("[a-fA-F0-9]+", "")],
                 separators: vec![],
                 examples: vec![("A1ff0.", Some((0, "A1ff0")))],
             },
             // regex with perl character classes
             Row {
-                rules: vec![Rule::pattern("\\w\\d\\s")],
+                rules: vec![Rule::pattern("\\w\\d\\s", "")],
                 separators: vec![],
                 examples: vec![("_0  ", Some((0, "_0 ")))],
             },
@@ -613,7 +678,7 @@ mod tests {
             Row {
                 rules: vec![Rule::repeat(Rule::seq(vec![
                     Rule::string("{"),
-                    Rule::pattern("[a-f]+"),
+                    Rule::pattern("[a-f]+", ""),
                     Rule::string("}"),
                 ]))],
                 separators: vec![],
@@ -626,9 +691,9 @@ mod tests {
             // longest match rule
             Row {
                 rules: vec![
-                    Rule::pattern("a|bc"),
-                    Rule::pattern("aa"),
-                    Rule::pattern("bcd"),
+                    Rule::pattern("a|bc", ""),
+                    Rule::pattern("aa", ""),
+                    Rule::pattern("bcd", ""),
                 ],
                 separators: vec![],
                 examples: vec![
@@ -642,7 +707,7 @@ mod tests {
             },
             // regex with an alternative including the empty string
             Row {
-                rules: vec![Rule::pattern("a(b|)+c")],
+                rules: vec![Rule::pattern("a(b|)+c", "")],
                 separators: vec![],
                 examples: vec![
                     ("ac.", Some((0, "ac"))),
@@ -652,8 +717,8 @@ mod tests {
             },
             // separators
             Row {
-                rules: vec![Rule::pattern("[a-f]+")],
-                separators: vec![Rule::string("\\\n"), Rule::pattern("\\s")],
+                rules: vec![Rule::pattern("[a-f]+", "")],
+                separators: vec![Rule::string("\\\n"), Rule::pattern("\\s", "")],
                 examples: vec![
                     ("  a", Some((0, "a"))),
                     ("  \nb", Some((0, "b"))),
@@ -664,11 +729,11 @@ mod tests {
             // shorter tokens with higher precedence
             Row {
                 rules: vec![
-                    Rule::prec(Precedence::Integer(2), Rule::pattern("abc")),
-                    Rule::prec(Precedence::Integer(1), Rule::pattern("ab[cd]e")),
-                    Rule::pattern("[a-e]+"),
+                    Rule::prec(Precedence::Integer(2), Rule::pattern("abc", "")),
+                    Rule::prec(Precedence::Integer(1), Rule::pattern("ab[cd]e", "")),
+                    Rule::pattern("[a-e]+", ""),
                 ],
-                separators: vec![Rule::string("\\\n"), Rule::pattern("\\s")],
+                separators: vec![Rule::string("\\\n"), Rule::pattern("\\s", "")],
                 examples: vec![
                     ("abceef", Some((0, "abc"))),
                     ("abdeef", Some((1, "abde"))),
@@ -678,13 +743,13 @@ mod tests {
             // immediate tokens with higher precedence
             Row {
                 rules: vec![
-                    Rule::prec(Precedence::Integer(1), Rule::pattern("[^a]+")),
+                    Rule::prec(Precedence::Integer(1), Rule::pattern("[^a]+", "")),
                     Rule::immediate_token(Rule::prec(
                         Precedence::Integer(2),
-                        Rule::pattern("[^ab]+"),
+                        Rule::pattern("[^ab]+", ""),
                     )),
                 ],
-                separators: vec![Rule::pattern("\\s")],
+                separators: vec![Rule::pattern("\\s", "")],
                 examples: vec![("cccb", Some((1, "ccc")))],
             },
             Row {
@@ -706,7 +771,7 @@ mod tests {
             // nested choices within sequences
             Row {
                 rules: vec![Rule::seq(vec![
-                    Rule::pattern("[0-9]+"),
+                    Rule::pattern("[0-9]+", ""),
                     Rule::choice(vec![
                         Rule::Blank,
                         Rule::choice(vec![Rule::seq(vec![
@@ -715,7 +780,7 @@ mod tests {
                                 Rule::Blank,
                                 Rule::choice(vec![Rule::string("+"), Rule::string("-")]),
                             ]),
-                            Rule::pattern("[0-9]+"),
+                            Rule::pattern("[0-9]+", ""),
                         ])]),
                     ]),
                 ])],
@@ -732,7 +797,7 @@ mod tests {
             },
             // nested groups
             Row {
-                rules: vec![Rule::seq(vec![Rule::pattern(r#"([^x\\]|\\(.|\n))+"#)])],
+                rules: vec![Rule::seq(vec![Rule::pattern(r#"([^x\\]|\\(.|\n))+"#, "")])],
                 separators: vec![],
                 examples: vec![("abcx", Some((0, "abc"))), ("abc\\0x", Some((0, "abc\\0")))],
             },
@@ -740,11 +805,11 @@ mod tests {
             Row {
                 rules: vec![
                     // Escaped forward slash (used in JS because '/' is the regex delimiter)
-                    Rule::pattern(r#"\/"#),
+                    Rule::pattern(r#"\/"#, ""),
                     // Escaped quotes
-                    Rule::pattern(r#"\"\'"#),
+                    Rule::pattern(r#"\"\'"#, ""),
                     // Quote preceded by a literal backslash
-                    Rule::pattern(r#"[\\']+"#),
+                    Rule::pattern(r#"[\\']+"#, ""),
                 ],
                 separators: vec![],
                 examples: vec![
@@ -756,8 +821,8 @@ mod tests {
             // unicode property escapes
             Row {
                 rules: vec![
-                    Rule::pattern(r#"\p{L}+\P{L}+"#),
-                    Rule::pattern(r#"\p{White_Space}+\P{White_Space}+[\p{White_Space}]*"#),
+                    Rule::pattern(r#"\p{L}+\P{L}+"#, ""),
+                    Rule::pattern(r#"\p{White_Space}+\P{White_Space}+[\p{White_Space}]*"#, ""),
                 ],
                 separators: vec![],
                 examples: vec![
@@ -767,17 +832,17 @@ mod tests {
             },
             // unicode property escapes in bracketed sets
             Row {
-                rules: vec![Rule::pattern(r#"[\p{L}\p{Nd}]+"#)],
+                rules: vec![Rule::pattern(r#"[\p{L}\p{Nd}]+"#, "")],
                 separators: vec![],
                 examples: vec![("abΨ12٣٣, ok", Some((0, "abΨ12٣٣")))],
             },
             // unicode character escapes
             Row {
                 rules: vec![
-                    Rule::pattern(r#"\u{00dc}"#),
-                    Rule::pattern(r#"\U{000000dd}"#),
-                    Rule::pattern(r#"\u00de"#),
-                    Rule::pattern(r#"\U000000df"#),
+                    Rule::pattern(r#"\u{00dc}"#, ""),
+                    Rule::pattern(r#"\U{000000dd}"#, ""),
+                    Rule::pattern(r#"\u00de"#, ""),
+                    Rule::pattern(r#"\U000000df"#, ""),
                 ],
                 separators: vec![],
                 examples: vec![
@@ -791,13 +856,13 @@ mod tests {
             Row {
                 rules: vec![
                     // Un-escaped curly braces
-                    Rule::pattern(r#"u{[0-9a-fA-F]+}"#),
+                    Rule::pattern(r#"u{[0-9a-fA-F]+}"#, ""),
                     // Already-escaped curly braces
-                    Rule::pattern(r#"\{[ab]{3}\}"#),
+                    Rule::pattern(r#"\{[ab]{3}\}"#, ""),
                     // Unicode codepoints
-                    Rule::pattern(r#"\u{1000A}"#),
+                    Rule::pattern(r#"\u{1000A}"#, ""),
                     // Unicode codepoints (lowercase)
-                    Rule::pattern(r#"\u{1000b}"#),
+                    Rule::pattern(r#"\u{1000b}"#, ""),
                 ],
                 separators: vec![],
                 examples: vec![
@@ -809,7 +874,7 @@ mod tests {
             },
             // Emojis
             Row {
-                rules: vec![Rule::pattern(r"\p{Emoji}+")],
+                rules: vec![Rule::pattern(r"\p{Emoji}+", "")],
                 separators: vec![],
                 examples: vec![
                     ("🐎", Some((0, "🐎"))),
@@ -822,7 +887,7 @@ mod tests {
             },
             // Intersection
             Row {
-                rules: vec![Rule::pattern(r"[[0-7]&&[4-9]]+")],
+                rules: vec![Rule::pattern(r"[[0-7]&&[4-9]]+", "")],
                 separators: vec![],
                 examples: vec![
                     ("456", Some((0, "456"))),
@@ -835,7 +900,7 @@ mod tests {
             },
             // Difference
             Row {
-                rules: vec![Rule::pattern(r"[[0-9]--[4-7]]+")],
+                rules: vec![Rule::pattern(r"[[0-9]--[4-7]]+", "")],
                 separators: vec![],
                 examples: vec![
                     ("123", Some((0, "123"))),
@@ -848,7 +913,7 @@ mod tests {
             },
             // Symmetric difference
             Row {
-                rules: vec![Rule::pattern(r"[[0-7]~~[4-9]]+")],
+                rules: vec![Rule::pattern(r"[[0-7]~~[4-9]]+", "")],
                 separators: vec![],
                 examples: vec![
                     ("123", Some((0, "123"))),
@@ -869,7 +934,7 @@ mod tests {
                 // [6-7]:                    y y
                 // [3-9]--[5-7]:       y y y     y y
                 // final regex:  y y   y y       y y
-                rules: vec![Rule::pattern(r"[[[0-5]--[2-4]]~~[[3-9]--[6-7]]]+")],
+                rules: vec![Rule::pattern(r"[[[0-5]--[2-4]]~~[[3-9]--[6-7]]]+", "")],
                 separators: vec![],
                 examples: vec![
                     ("01", Some((0, "01"))),

--- a/cli/src/generate/prepare_grammar/extract_tokens.rs
+++ b/cli/src/generate/prepare_grammar/extract_tokens.rs
@@ -320,7 +320,7 @@ mod test {
                 "rule_0",
                 Rule::repeat(Rule::seq(vec![
                     Rule::string("a"),
-                    Rule::pattern("b"),
+                    Rule::pattern("b", ""),
                     Rule::choice(vec![
                         Rule::non_terminal(1),
                         Rule::non_terminal(2),
@@ -331,8 +331,8 @@ mod test {
                     ]),
                 ])),
             ),
-            Variable::named("rule_1", Rule::pattern("e")),
-            Variable::named("rule_2", Rule::pattern("b")),
+            Variable::named("rule_1", Rule::pattern("e", "")),
+            Variable::named("rule_2", Rule::pattern("b", "")),
             Variable::named(
                 "rule_3",
                 Rule::seq(vec![Rule::non_terminal(2), Rule::Blank]),
@@ -378,12 +378,12 @@ mod test {
             lexical_grammar.variables,
             vec![
                 Variable::anonymous("a", Rule::string("a")),
-                Variable::auxiliary("rule_0_token1", Rule::pattern("b")),
+                Variable::auxiliary("rule_0_token1", Rule::pattern("b", "")),
                 Variable::auxiliary(
                     "rule_0_token2",
                     Rule::repeat(Rule::choice(vec![Rule::string("c"), Rule::string("d"),]))
                 ),
-                Variable::named("rule_1", Rule::pattern("e")),
+                Variable::named("rule_1", Rule::pattern("e", "")),
             ]
         );
     }
@@ -411,7 +411,7 @@ mod test {
     fn test_extracting_extra_symbols() {
         let mut grammar = build_grammar(vec![
             Variable::named("rule_0", Rule::string("x")),
-            Variable::named("comment", Rule::pattern("//.*")),
+            Variable::named("comment", Rule::pattern("//.*", "")),
         ]);
         grammar.extra_symbols = vec![Rule::string(" "), Rule::non_terminal(1)];
 

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -764,7 +764,6 @@ impl Generator {
         indent!(self);
 
         add_line!(self, "START_LEXER();");
-        add_line!(self, "eof = lexer->eof(lexer);");
         add_line!(self, "switch (state) {{");
 
         indent!(self);

--- a/cli/src/generate/rules.rs
+++ b/cli/src/generate/rules.rs
@@ -56,7 +56,7 @@ pub(crate) struct Symbol {
 pub(crate) enum Rule {
     Blank,
     String(String),
-    Pattern(String),
+    Pattern(String, String),
     NamedSymbol(String),
     Symbol(Symbol),
     Choice(Vec<Rule>),
@@ -187,8 +187,8 @@ impl Rule {
         Rule::String(value.to_string())
     }
 
-    pub fn pattern(value: &'static str) -> Self {
-        Rule::Pattern(value.to_string())
+    pub fn pattern(value: &'static str, flags: &'static str) -> Self {
+        Rule::Pattern(value.to_string(), flags.to_string())
     }
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,6 @@ include = [
 ]
 
 [dependencies]
-lazy_static = { version = "1.4.0", optional = true }
 regex = "1.9.1"
 
 [build-dependencies]

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -722,7 +722,7 @@ extern "C" {
     ) -> TSStateId;
 }
 extern "C" {
-    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using `ts_lookahead_iterator_advance` and\n `ts_lookahead_iterator_current_symbol` will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node may be appropriate."]
+    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using `ts_lookahead_iterator_next` and\n `ts_lookahead_iterator_current_symbol` will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node may be appropriate."]
     pub fn ts_lookahead_iterator_new(
         self_: *const TSLanguage,
         state: TSStateId,
@@ -753,7 +753,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = " Advance the lookahead iterator to the next symbol.\n\n This returns `true` if there is a new symbol and `false` otherwise."]
-    pub fn ts_lookahead_iterator_advance(self_: *mut TSLookaheadIterator) -> bool;
+    pub fn ts_lookahead_iterator_next(self_: *mut TSLookaheadIterator) -> bool;
 }
 extern "C" {
     #[doc = " Get the current symbol of the lookahead iterator;"]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1509,9 +1509,9 @@ impl LookaheadIterator {
 impl Iterator for LookaheadNamesIterator<'_> {
     type Item = &'static str;
 
-    #[doc(alias = "ts_lookahead_iterator_advance")]
+    #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe { ffi::ts_lookahead_iterator_advance(self.0 .0.as_ptr()) }
+        unsafe { ffi::ts_lookahead_iterator_next(self.0 .0.as_ptr()) }
             .then(|| self.0.current_symbol_name())
     }
 }
@@ -1519,11 +1519,10 @@ impl Iterator for LookaheadNamesIterator<'_> {
 impl Iterator for LookaheadIterator {
     type Item = u16;
 
-    #[doc(alias = "ts_lookahead_iterator_advance")]
+    #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
         // the first symbol is always `0` so we can safely skip it
-        unsafe { ffi::ts_lookahead_iterator_advance(self.0.as_ptr()) }
-            .then(|| self.current_symbol())
+        unsafe { ffi::ts_lookahead_iterator_next(self.0.as_ptr()) }.then(|| self.current_symbol())
     }
 }
 

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1025,7 +1025,7 @@ class LookaheadIterable {
     const self = this;
     return {
       next() {
-        if (C._ts_lookahead_iterator_advance(self[0])) {
+        if (C._ts_lookahead_iterator_next(self[0])) {
           return { done: false, value: self.currentType };
         }
 

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -122,6 +122,6 @@
   "_ts_lookahead_iterator_delete",
   "_ts_lookahead_iterator_reset_state",
   "_ts_lookahead_iterator_reset",
-  "_ts_lookahead_iterator_advance",
+  "_ts_lookahead_iterator_next",
   "_ts_lookahead_iterator_current_symbol"
 ]

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1076,7 +1076,7 @@ TSStateId ts_language_next_state(const TSLanguage *self, TSStateId state, TSSymb
  *
  * This returns `NULL` if state is invalid for the language.
  *
- * Repeatedly using `ts_lookahead_iterator_advance` and
+ * Repeatedly using `ts_lookahead_iterator_next` and
  * `ts_lookahead_iterator_current_symbol` will generate valid symbols in the
  * given parse state. Newly created lookahead iterators will contain the `ERROR`
  * symbol.
@@ -1119,7 +1119,7 @@ const TSLanguage *ts_lookahead_iterator_language(const TSLookaheadIterator *self
  *
  * This returns `true` if there is a new symbol and `false` otherwise.
 */
-bool ts_lookahead_iterator_advance(TSLookaheadIterator *self);
+bool ts_lookahead_iterator_next(TSLookaheadIterator *self);
 
 /**
  * Get the current symbol of the lookahead iterator;

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -129,16 +129,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -146,7 +139,8 @@ struct TSLanguage {
   lexer->advance(lexer, skip);  \
   start:                        \
   skip = false;                 \
-  lookahead = lexer->lookahead;
+  lookahead = lexer->lookahead; \
+  eof = lexer->eof(lexer);
 
 #define ADVANCE(state_value) \
   {                          \

--- a/lib/src/atomic.h
+++ b/lib/src/atomic.h
@@ -1,6 +1,7 @@
 #ifndef TREE_SITTER_ATOMIC_H_
 #define TREE_SITTER_ATOMIC_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __TINYC__
@@ -46,11 +47,19 @@ static inline size_t atomic_load(const volatile size_t *p) {
 }
 
 static inline uint32_t atomic_inc(volatile uint32_t *p) {
-  return __sync_add_and_fetch(p, 1U);
+  #ifdef __ATOMIC_RELAXED
+    return __atomic_add_fetch(p, 1U, __ATOMIC_RELAXED);
+  #else
+    return __sync_add_and_fetch(p, 1U);
+  #endif
 }
 
 static inline uint32_t atomic_dec(volatile uint32_t *p) {
-  return __sync_sub_and_fetch(p, 1U);
+  #ifdef __ATOMIC_RELAXED
+    return __atomic_sub_fetch(p, 1U, __ATOMIC_RELAXED);
+  #else
+    return __sync_sub_and_fetch(p, 1U);
+  #endif
 }
 
 #endif

--- a/lib/src/atomic.h
+++ b/lib/src/atomic.h
@@ -48,7 +48,7 @@ static inline size_t atomic_load(const volatile size_t *p) {
 
 static inline uint32_t atomic_inc(volatile uint32_t *p) {
   #ifdef __ATOMIC_RELAXED
-    return __atomic_add_fetch(p, 1U, __ATOMIC_RELAXED);
+    return __atomic_add_fetch(p, 1U, __ATOMIC_SEQ_CST);
   #else
     return __sync_add_and_fetch(p, 1U);
   #endif
@@ -56,7 +56,7 @@ static inline uint32_t atomic_inc(volatile uint32_t *p) {
 
 static inline uint32_t atomic_dec(volatile uint32_t *p) {
   #ifdef __ATOMIC_RELAXED
-    return __atomic_sub_fetch(p, 1U, __ATOMIC_RELAXED);
+    return __atomic_sub_fetch(p, 1U, __ATOMIC_SEQ_CST);
   #else
     return __sync_sub_and_fetch(p, 1U);
   #endif

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -192,9 +192,9 @@ bool ts_lookahead_iterator_reset(TSLookaheadIterator *self, const TSLanguage *la
   return true;
 }
 
-bool ts_lookahead_iterator_advance(TSLookaheadIterator *self) {
+bool ts_lookahead_iterator_next(TSLookaheadIterator *self) {
   LookaheadIterator *iterator = (LookaheadIterator *)self;
-  return ts_lookahead_iterator_next(iterator);
+  return ts_lookahead_iterator__next(iterator);
 }
 
 TSSymbol ts_lookahead_iterator_current_symbol(const TSLookaheadIterator *self) {

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -136,7 +136,7 @@ static inline LookaheadIterator ts_language_lookaheads(
   };
 }
 
-static inline bool ts_lookahead_iterator_next(LookaheadIterator *self) {
+static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
   // For small parse states, valid symbols are listed explicitly,
   // grouped by their value. There's no need to look up the actions
   // again until moving to the next group.

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1265,7 +1265,7 @@ static void ts_query__perform_analysis(
       // Follow every possible path in the parse table, but only visit states that
       // are part of the subgraph for the current symbol.
       LookaheadIterator lookahead_iterator = ts_language_lookaheads(self->language, parse_state);
-      while (ts_lookahead_iterator_next(&lookahead_iterator)) {
+      while (ts_lookahead_iterator__next(&lookahead_iterator)) {
         TSSymbol sym = lookahead_iterator.symbol;
 
         AnalysisSubgraphNode successor = {
@@ -1536,7 +1536,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   for (TSStateId state = 1; state < (uint16_t)self->language->state_count; state++) {
     unsigned subgraph_index, exists;
     LookaheadIterator lookahead_iterator = ts_language_lookaheads(self->language, state);
-    while (ts_lookahead_iterator_next(&lookahead_iterator)) {
+    while (ts_lookahead_iterator__next(&lookahead_iterator)) {
       if (lookahead_iterator.action_count) {
         for (unsigned i = 0; i < lookahead_iterator.action_count; i++) {
           const TSParseAction *action = &lookahead_iterator.actions[i];


### PR DESCRIPTION
![Screenshot from 2023-07-19 03-27-28](https://github.com/amaanq/tree-sitter/assets/14666676/c15e5c92-d630-4795-8258-14af97c7766b)

```
cargo test test_corpus_for_
```

There tons of warnings from c/cpp compilers on external scanners.

Three grammars don't possible to enable due and I suspect due to clashes on function names in external scanner or something similar because they get in a one large file by a linker while dynamic loader behaves differently.