### PR TITLE
ci riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: ${{ matrix.platform }} (${{ matrix.target }}) (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: ${{ contains(matrix.os, 'riscv') && 90 || 40 }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +21,7 @@ jobs:
           - linux-x64
           - linux-x86
           - linux-powerpc64
+          - linux-riscv64
           - windows-arm64
           - windows-x64
           - windows-x86
@@ -32,17 +33,18 @@ jobs:
           # When adding a new `target`:
           # 1. Define a new platform alias above
           # 2. Add a new record to the matrix map in `crates/cli/npm/install.js`
-          - { platform: linux-arm64     , target: aarch64-unknown-linux-gnu     , os: ubuntu-24.04-arm }
-          - { platform: linux-arm       , target: armv7-unknown-linux-gnueabihf , os: ubuntu-24.04-arm }
-          - { platform: linux-x64       , target: x86_64-unknown-linux-gnu      , os: ubuntu-24.04     }
-          - { platform: linux-x86       , target: i686-unknown-linux-gnu        , os: ubuntu-24.04     }
-          - { platform: linux-powerpc64 , target: powerpc64-unknown-linux-gnu   , os: ubuntu-24.04     }
-          - { platform: windows-arm64   , target: aarch64-pc-windows-msvc       , os: windows-11-arm   }
-          - { platform: windows-x64     , target: x86_64-pc-windows-msvc        , os: windows-2025     }
-          - { platform: windows-x86     , target: i686-pc-windows-msvc          , os: windows-2025     }
-          - { platform: macos-arm64     , target: aarch64-apple-darwin          , os: macos-15         }
-          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-15-intel   }
-          - { platform: wasm32          , target: wasm32-unknown-unknown        , os: ubuntu-24.04     }
+          - { platform: linux-arm64     , target: aarch64-unknown-linux-gnu     , os: ubuntu-24.04-arm   }
+          - { platform: linux-arm       , target: armv7-unknown-linux-gnueabihf , os: ubuntu-24.04-arm   }
+          - { platform: linux-x64       , target: x86_64-unknown-linux-gnu      , os: ubuntu-24.04       }
+          - { platform: linux-x86       , target: i686-unknown-linux-gnu        , os: ubuntu-24.04       }
+          - { platform: linux-powerpc64 , target: powerpc64-unknown-linux-gnu   , os: ubuntu-24.04       }
+          - { platform: linux-riscv64   , target: riscv64gc-unknown-linux-gnu   , os: ubuntu-24.04-riscv }
+          - { platform: windows-arm64   , target: aarch64-pc-windows-msvc       , os: windows-11-arm     }
+          - { platform: windows-x64     , target: x86_64-pc-windows-msvc        , os: windows-2025       }
+          - { platform: windows-x86     , target: i686-pc-windows-msvc          , os: windows-2025       }
+          - { platform: macos-arm64     , target: aarch64-apple-darwin          , os: macos-15           }
+          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-15-intel     }
+          - { platform: wasm32          , target: wasm32-unknown-unknown        , os: ubuntu-24.04       }
 
           # Extra features
           - { platform: linux-arm64     , features: wasm }
@@ -121,6 +123,12 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         target: ${{ matrix.target }}
+
+    - name: Install clang
+      if: matrix.platform == 'linux-riscv64'
+      run: |
+        sudo apt-get update -qy && sudo apt-get install -qy clang libclang-dev
+        echo 'BINDGEN_EXTRA_CLANG_ARGS=--target=riscv64-unknown-linux-gnu' >> $GITHUB_ENV
 
     - name: Install cross-compilation toolchain
       if: matrix.cross

--- a/crates/cli/npm/install.js
+++ b/crates/cli/npm/install.js
@@ -25,6 +25,7 @@ const matrix = {
         'x64': { name: 'x64' },
         'x86': { name: 'x86' },
         'ppc64': { name: 'powerpc64' },
+        'riscv64': { name: 'riscv64' },
       }
     },
     'win32': {


### PR DESCRIPTION
- **refactor(query): remove `alternative_is_immediate`**
- **fix(query): don't add copies for quantifier steps outside alternations**
- **ci(tests): run required tests on all PRs**
- **build(deps): cargo update**
- **build(deps): bump wasi-sdk to v32**
- **build(deps): bump binaryen to v127**
- **Revert "feat: allow `-` in grammar names"**
- **docs: indicate that dashes are not permitted in parser names**
- **ci(release): publish zip archives for tree-sitter-cli**
- **build(deps): bump flatted from 3.3.1 to 3.4.1 in /crates/cli/eslint**
- **build(deps): bump anstyle from 1.0.13 to 1.0.14 in the cargo group**
- **fix(loader): unconditionally import `Mutex`**
- **fix(generate): allow disabling `qjs-rt` feature from CLI**
- **fix(lib): document invariants that must be upheld for `TSInputEdit`**
- **ci: bump actions/create-github-app-token in the actions group**
- **build(deps): bump cc from 1.2.56 to 1.2.57 in the cargo group**
- **build(deps): bump flatted from 3.3.2 to 3.4.2 in /lib/binding_web**
- **build(deps): bump flatted from 3.4.1 to 3.4.2 in /crates/cli/eslint**
- **build(deps): bump brace-expansion in /crates/cli/eslint**
- **docs: update WASM build requirements for wasi-sdk**
- **perf(parser): use `LookaheadIterator` in error recovery's all-symbol scan**
- **fix(rust): address new nightly lints**
- **fix(rust): correct various typos**
- **fix(docs): correct various typos**
- **fix(lib): correct various typos**
- **fix(parser): sort error recovery reductions for deterministic ordering**
- **build(deps): bump cc from 1.2.57 to 1.2.58 in the cargo group**
- **ci: bump the actions group with 2 updates**
- **perf(loader): extract name from grammar.json without regex**
- **generate: remove comment cleaning for `grammar.json`**
- **perf(cli): buffer stdout in parse and query output**
- **perf(cli): minor allocation and write call reductions**
- **Fix wasm loading of languages w/ multiple reserved word sets (#5475)**
- **fix(loader): don't discard CC wrapper command specified in `CC` variable**
- **generate: avoid panicking when a supertype only has hidden external token children**
- **perf(cli): replace regex with manual parsing in test file parser**
- **fix(loader): replace flock-based compilation lock with atomic lock file**
- **fix(test): split up cli testing test**
- **fix(loader): remove `CROSS_RUNNER` temorary directory path**
- **ci(actions): bump actions/cache to v5**
- **build(deps): bump the npm group across 1 directory with 4 updates**
- **build(deps): cargo update**
- **build(deps): bump the npm group across 1 directory with 4 updates**
- **ci(nvim-ts): minor improvements**
- **feat(generate): don't require `tree-sitter.json` for ABI 15**
- **build(deps): bump binaryen to v129**
- **fix(ci): include wasi-sdk and binaryen version files in fixture cache hash**
- **perf(generate): optimize minimize_parse_table with precomputation and compact types**
- **perf(generate): optimize token conflict analysis and symbol handling**
- **perf(generate): use `FxHasher` over default hash implementation**
- **perf(generate): optimize NFA operations and token conflict precomputation**
- **perf(generate): use bitsets for coincident tokens and `TokenConflictMap`**
- **ci(nvim-ts): build nvim against PR lib**
- **build(deps): bump vite from 7.3.1 to 7.3.2 in /lib/binding_web**
- **ci(nvim-ts): further improvements to Neovim build**
- **build(deps): bump wasmtime-c-api to v36.0.7**
- **build(deps): cargo update**
- **build(deps): bump rand from 0.10.0 to 0.10.1**
- **ci: bump the actions group with 2 updates**
- **ci: add linux-riscv64 build target**
